### PR TITLE
The ROOT directory is not what you think it is

### DIFF
--- a/common/scripts/configure-mip-local.sh
+++ b/common/scripts/configure-mip-local.sh
@@ -374,10 +374,10 @@ git add .
 echo
 echo "Generation of the standard configuration for MIP Local complete!"
 echo
-echo "You can review the configuration located in $ROOT/envs/mip-local/etc/ansible/"
+echo "You can review the configuration located in $ROOT/../../envs/mip-local/etc/ansible/"
 echo "and customise it further for your environment and needs."
 echo "More information about the configuration settings can be found in"
-echo "  $ROOT/docs/configuration/"
+echo "  $ROOT/../../docs/configuration/"
 echo
 echo "Before starting the installation, please commit the configuration in Git:"
 echo "  git commit -m 'Configuration for MIP Local'"


### PR DESCRIPTION
The `ROOT` directory is the subdirectory that contains this script - currently `common/scripts`. The `envs` and `docs` subdirectories are created in the actual root directory of this repository, two levels above `common/scripts`. This happens because of this part of the code:
```
ROOT=$(get_script_dir)
cd "$ROOT/../.."
```
Alternatively, you can change the above code to something like:
```
ROOT=$(get_script_dir)
ROOT=`dirname "$ROOT"`
ROOT=`dirname "$ROOT"`
cd "$ROOT"
```

Fixes #41.