### PR TITLE
The ROOT directory is not what you think it is

### DIFF
--- a/common/scripts/configure-mip-local.sh
+++ b/common/scripts/configure-mip-local.sh
@@ -21,12 +21,12 @@ get_script_dir () {
           SOURCE="$( readlink "$SOURCE" )"
           [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
      done
-     cd -P "$( dirname "$SOURCE" )"
+     cd -P "$( dirname "$SOURCE" )/../.."
      pwd
 }
 
 ROOT=$(get_script_dir)
-cd "$ROOT/../.."
+cd "$ROOT"
 
 which ansible > /dev/null || ./common/scripts/bootstrap.sh
 


### PR DESCRIPTION
The `ROOT` directory used to be the subdirectory that contains this script - currently `common/scripts`. The `envs` and `docs` subdirectories are created in the actual root directory of this repository, two levels above `common/scripts`. This happened because of this part of the code:
```
	ROOT=$(get_script_dir)
	cd "$ROOT/../.."
```
Modify _get_script_dir_() to return the actual root directory and correctly set `ROOT`.

Fixes #41 and replaces #40.