### PR TITLE
These git commands are not needed any more

### DIFF
--- a/docs/installation/mip-local.md
+++ b/docs/installation/mip-local.md
@@ -44,8 +44,6 @@ See below for more information on the configuration parameters.
 - Store the configuration in Git, encrypt the passwords and confidential information associated to the host(s).
 
 ```sh
-  git-crypt init
-  git add .
   git commit -m "Configuration for MIP Local"
 
 ```


### PR DESCRIPTION
Remove these git commands from the installation documentation. They are not needed any more because ./common/scripts/configure-mip-local.sh runs them for us since 67f4246.

Fixes #46.