### PR TITLE
Specify the path of file .environment

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-[ -f .environment ] && source .environment
+[ -f .environment ] && source ./.environment
 
 # shellcheck disable=SC2086
 : ${DATACENTER:=federation}


### PR DESCRIPTION
We want source to look for file `.environment` in the same directory as `setup.sh` itself, not in the user's `PATH`. Indeed I had other software with an `.environment` file in my `PATH`. Perhaps that's bad practice but that's beyond my control. If we follow the installation instructions, `setup.sh` is in the current directory because we run it as `./setup.sh`.

From the [Bash Reference Manual](https://www.gnu.org/software/bash/manual/html_node/Bourne-Shell-Builtins.html):
> _`. filename [arguments]`_
>
> Read and execute commands from the _filename_ argument in the current shell context. If _filename_ does not contain a slash, the `PATH` variable is used to find filename. When Bash is not in POSIX mode, the current directory is searched if _filename_ is not found in `$PATH`.

Fixes #48.