### PR TITLE
Remove HEAD from limit_except directive in nginx conf files.

### DIFF
--- a/vars/federation-mip-services.yml
+++ b/vars/federation-mip-services.yml
@@ -49,7 +49,7 @@ nginx_sites:
       #    return      301 https://$server_name$request_uri;
       #}
       location /mesos/ {
-          limit_except GET HEAD {
+          limit_except GET {
             deny all;
           }
           rewrite             ^/mesos(/.*) $1 break;
@@ -61,7 +61,7 @@ nginx_sites:
           sub_filter_once off;
       }
       location /marathon/ {
-          limit_except GET HEAD {
+          limit_except GET {
             deny all;
           }
           rewrite             ^/marathon(/.*) $1 break;
@@ -71,7 +71,7 @@ nginx_sites:
           proxy_buffering     on;
       }
       location /chronos/ {
-          limit_except GET HEAD {
+          limit_except GET {
             deny all;
           }
           rewrite             ^/chronos(/.*) $1 break;

--- a/vars/mip-services.yml
+++ b/vars/mip-services.yml
@@ -41,7 +41,7 @@ nginx_sites:
       index index.html;
       sub_filter_types text/html;
       location /mesos/ {
-          limit_except GET HEAD {
+          limit_except GET {
             deny all;
           }
           rewrite             ^/mesos(/.*) $1 break;
@@ -53,7 +53,7 @@ nginx_sites:
           sub_filter_once off;
       }
       location /marathon/ {
-          limit_except GET HEAD {
+          limit_except GET {
             deny all;
           }
           rewrite             ^/marathon(/.*) $1 break;
@@ -63,7 +63,7 @@ nginx_sites:
           proxy_buffering     on;
       }
       location /chronos/ {
-          limit_except GET HEAD {
+          limit_except GET {
             deny all;
           }
           rewrite             ^/chronos(/.*) $1 break;


### PR DESCRIPTION
Removing unnecessary http method. HEAD is implicit when GET is present.

For further reading about this from the nginx docs: http://nginx.org/en/docs/http/ngx_http_core_module.html#limit_except